### PR TITLE
[61] Drop ancient history and add realtime pruning

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1979,7 +1979,8 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node, readonly bool) ethdb.
 		chainDb, err = stack.OpenDatabase(name, cache, handles, "", readonly)
 	} else {
 		name := "chaindata"
-		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly)
+		// open db as freezer with disabled freeze, and no interruption
+		chainDb, err = stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "", readonly, false, false)
 	}
 	if err != nil {
 		Fatalf("Could not open database: %v", err)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -796,7 +796,8 @@ func TestFastVsFullChains(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	// [bsc] adding disabledFreeze and isLastOffset param
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -892,7 +893,8 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 			t.Fatalf("failed to create temp freezer dir: %v", err)
 		}
 		defer os.Remove(dir)
-		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false)
+		// [bsc] adding disabledFreeze and isLastOffset param
+		db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false, false, false)
 		if err != nil {
 			t.Fatalf("failed to create temp freezer db: %v", err)
 		}
@@ -1764,7 +1766,8 @@ func TestBlockchainRecovery(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
+	// [bsc] adding disabledFreeze and isLastOffset param
+	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
@@ -1835,6 +1838,7 @@ func TestInsertReceiptChainRollback(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
+	// [bsc] adding disabledFreeze and isLastOffset param
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -2102,6 +2106,7 @@ func testInsertKnownChainData(t *testing.T, typ string) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(dir)
+	// [bsc] adding disabledFreeze and isLastOffset param
 	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -2266,6 +2271,7 @@ func testInsertKnownChainDataWithMerging(t *testing.T, typ string, mergeHeight i
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(dir)
+	// [bsc] adding disabledFreeze and isLastOffset param
 	chaindb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), dir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -2576,6 +2582,7 @@ func TestTransactionIndices(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
+	// [bsc] adding disabledFreeze and isLastOffset param
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -2624,6 +2631,7 @@ func TestTransactionIndices(t *testing.T) {
 	}
 
 	// Reconstruct a block chain which only reserves HEAD-64 tx indices
+	// [bsc] adding disabledFreeze and isLastOffset param
 	ancientDb, err = rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)
@@ -2703,6 +2711,7 @@ func TestSkipStaleTxIndicesInSnapSync(t *testing.T) {
 		t.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.Remove(frdir)
+	// [bsc] adding disabledFreeze and isLastOffset param
 	ancientDb, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), frdir, "", false)
 	if err != nil {
 		t.Fatalf("failed to create temp freezer db: %v", err)

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -168,6 +168,10 @@ func (hc *HeaderChain) Reorg(headers []*types.Header) error {
 			headHash   = header.Hash()
 		)
 		for rawdb.ReadCanonicalHash(hc.chainDb, headNumber) != headHash {
+			// [bsc] exit if frozen ancient same as the last block
+			if frozen, _ := hc.chainDb.Ancients(); frozen == headNumber {
+				break
+			}
 			rawdb.WriteCanonicalHash(batch, headHash, headNumber)
 			if headNumber == 0 {
 				break // It shouldn't be reached

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -441,7 +441,7 @@ func TestAncientStorage(t *testing.T) {
 	}
 	defer os.RemoveAll(frdir)
 
-	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false)
+	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false, false, false) // [bsc] adding isDisableFreeze & isLastOffset param
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}
@@ -582,7 +582,7 @@ func BenchmarkWriteAncientBlocks(b *testing.B) {
 		b.Fatalf("failed to create temp freezer dir: %v", err)
 	}
 	defer os.RemoveAll(frdir)
-	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false)
+	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false) // [bsc] adding isDisableFreeze & isLastOffset param
 	if err != nil {
 		b.Fatalf("failed to create database with ancient backend")
 	}
@@ -892,7 +892,7 @@ func TestHeadersRLPStorage(t *testing.T) {
 	}
 	defer os.Remove(frdir)
 
-	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false)
+	db, err := NewDatabaseWithFreezer(NewMemoryDatabase(), frdir, "", false, false, false) // [bsc] adding isDisableFreeze & isLastOffset param
 	if err != nil {
 		t.Fatalf("failed to create database with ancient backend")
 	}

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -37,7 +37,7 @@ type freezerBatch struct {
 func newFreezerBatch(f *freezer) *freezerBatch {
 	batch := &freezerBatch{tables: make(map[string]*freezerTableBatch, len(f.tables))}
 	for kind, table := range f.tables {
-		batch.tables[kind] = table.newBatch()
+		batch.tables[kind] = table.newBatch(f.offset) // [bsc] putting offset as consideration
 	}
 	return batch
 }
@@ -91,11 +91,13 @@ type freezerTableBatch struct {
 	indexBuffer []byte
 	curItem     uint64 // expected index of next append
 	totalBytes  int64  // counts written bytes since reset
+	offset      uint64 // [bsc] adding offset as consideration
 }
 
 // newBatch creates a new batch for the freezer table.
-func (t *freezerTable) newBatch() *freezerTableBatch {
-	batch := &freezerTableBatch{t: t}
+// [bsc] adding offset as consideration
+func (t *freezerTable) newBatch(offset uint64) *freezerTableBatch {
+	batch := &freezerTableBatch{t: t, offset: offset}
 	if !t.noCompression {
 		batch.sb = new(snappyBuffer)
 	}
@@ -107,7 +109,8 @@ func (t *freezerTable) newBatch() *freezerTableBatch {
 func (batch *freezerTableBatch) reset() {
 	batch.dataBuffer = batch.dataBuffer[:0]
 	batch.indexBuffer = batch.indexBuffer[:0]
-	batch.curItem = atomic.LoadUint64(&batch.t.items)
+	curItem := batch.t.items + batch.offset // [bsc] adding offset as consideration
+	batch.curItem = atomic.LoadUint64(&curItem)
 	batch.totalBytes = 0
 }
 
@@ -201,7 +204,8 @@ func (batch *freezerTableBatch) commit() error {
 
 	// Update headBytes of table.
 	batch.t.headBytes += dataSize
-	atomic.StoreUint64(&batch.t.items, batch.curItem)
+	items := batch.curItem - batch.offset // [bsc] adding offset as consideration
+	atomic.StoreUint64(&batch.t.items, items)
 
 	// Update metrics.
 	batch.t.sizeGauge.Inc(dataSize + indexSize)

--- a/core/rawdb/freezer_table.go
+++ b/core/rawdb/freezer_table.go
@@ -931,7 +931,7 @@ func (t *freezerTable) dumpIndex(w io.Writer, start, stop int64) {
 // Fill adds empty data till given number (convenience method for backward compatibilty)
 func (t *freezerTable) Fill(number uint64) error {
 	if t.items < number {
-		b := t.newBatch()
+		b := t.newBatch(0) // [bsc] putting offset 0 as initial
 		log.Info("Filling all data into freezer for backward compatablity", "name", t.name, "items", t.items, "number", number)
 		for t.items < number {
 			if err := b.Append(t.items, nil); err != nil {

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -99,7 +99,7 @@ func TestFreezerBasicsClosing(t *testing.T) {
 	// In-between writes, the table is closed and re-opened.
 	for x := 0; x < 255; x++ {
 		data := getChunk(15, x)
-		batch := f.newBatch()
+		batch := f.newBatch(0) // [bsc] putting 0 offset as initial
 		require.NoError(t, batch.AppendRaw(uint64(x), data))
 		require.NoError(t, batch.commit())
 		f.Close()
@@ -227,7 +227,7 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 			t.Errorf("Expected error for missing index entry")
 		}
 		// We should now be able to store items again, from item = 1
-		batch := f.newBatch()
+		batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 		for x := 1; x < 0xff; x++ {
 			require.NoError(t, batch.AppendRaw(uint64(x), getChunk(15, ^x)))
 		}
@@ -417,7 +417,7 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Write 80 bytes, splitting out into two files
-		batch := f.newBatch()
+		batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 		require.NoError(t, batch.AppendRaw(0, getChunk(40, 0xFF)))
 		require.NoError(t, batch.AppendRaw(1, getChunk(40, 0xEE)))
 		require.NoError(t, batch.commit())
@@ -455,7 +455,7 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 		}
 
 		// Write 40 bytes
-		batch := f.newBatch()
+		batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 		require.NoError(t, batch.AppendRaw(1, getChunk(40, 0xDD)))
 		require.NoError(t, batch.commit())
 
@@ -512,7 +512,7 @@ func TestFreezerReadAndTruncate(t *testing.T) {
 		f.truncateHead(0)
 
 		// Write the data again
-		batch := f.newBatch()
+		batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 		for x := 0; x < 30; x++ {
 			require.NoError(t, batch.AppendRaw(uint64(x), getChunk(15, ^x)))
 		}
@@ -534,7 +534,7 @@ func TestFreezerOffset(t *testing.T) {
 		}
 
 		// Write 6 x 20 bytes, splitting out into three files
-		batch := f.newBatch()
+		batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 		require.NoError(t, batch.AppendRaw(0, getChunk(20, 0xFF)))
 		require.NoError(t, batch.AppendRaw(1, getChunk(20, 0xEE)))
 
@@ -598,7 +598,7 @@ func TestFreezerOffset(t *testing.T) {
 		t.Log(f.dumpIndexString(0, 100))
 
 		// It should allow writing item 6.
-		batch := f.newBatch()
+		batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 		require.NoError(t, batch.AppendRaw(6, getChunk(20, 0x99)))
 		require.NoError(t, batch.commit())
 
@@ -676,7 +676,7 @@ func TestTruncateTail(t *testing.T) {
 	}
 
 	// Write 7 x 20 bytes, splitting out into four files
-	batch := f.newBatch()
+	batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 	require.NoError(t, batch.AppendRaw(0, getChunk(20, 0xFF)))
 	require.NoError(t, batch.AppendRaw(1, getChunk(20, 0xEE)))
 	require.NoError(t, batch.AppendRaw(2, getChunk(20, 0xdd)))
@@ -791,7 +791,7 @@ func TestTruncateHead(t *testing.T) {
 	}
 
 	// Write 7 x 20 bytes, splitting out into four files
-	batch := f.newBatch()
+	batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 	require.NoError(t, batch.AppendRaw(0, getChunk(20, 0xFF)))
 	require.NoError(t, batch.AppendRaw(1, getChunk(20, 0xEE)))
 	require.NoError(t, batch.AppendRaw(2, getChunk(20, 0xdd)))
@@ -816,7 +816,7 @@ func TestTruncateHead(t *testing.T) {
 	})
 
 	// Append new items
-	batch = f.newBatch()
+	batch = f.newBatch(0) // [bsc] putting 0 as initial offset
 	require.NoError(t, batch.AppendRaw(4, getChunk(20, 0xbb)))
 	require.NoError(t, batch.AppendRaw(5, getChunk(20, 0xaa)))
 	require.NoError(t, batch.AppendRaw(6, getChunk(20, 0x11)))
@@ -880,7 +880,7 @@ func getChunk(size int, b int) []byte {
 func writeChunks(t *testing.T, ft *freezerTable, n int, length int) {
 	t.Helper()
 
-	batch := ft.newBatch()
+	batch := ft.newBatch(0) // [bsc] putting 0 as initial offset
 	for i := 0; i < n; i++ {
 		if err := batch.AppendRaw(uint64(i), getChunk(length, i)); err != nil {
 			t.Fatalf("AppendRaw(%d, ...) returned error: %v", i, err)
@@ -1076,7 +1076,7 @@ func TestFreezerReadonly(t *testing.T) {
 
 	// Case 5: Now write some data via a batch.
 	// This should fail either during AppendRaw or Commit
-	batch := f.newBatch()
+	batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 	writeErr := batch.AppendRaw(32, make([]byte, 1))
 	if writeErr == nil {
 		writeErr = batch.commit()
@@ -1231,7 +1231,7 @@ func runRandTest(rt randTest) bool {
 			}
 
 		case opAppend:
-			batch := f.newBatch()
+			batch := f.newBatch(0) // [bsc] putting 0 as initial offset
 			for i := 0; i < len(step.items); i++ {
 				batch.AppendRaw(step.items[i], step.blobs[i])
 			}

--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -116,7 +116,7 @@ func TestFreezerModifyRollback(t *testing.T) {
 
 	// Reopen and check that the rolled-back data doesn't reappear.
 	tables := map[string]bool{"test": true}
-	f2, err := newFreezer(dir, "", false, 2049, tables)
+	f2, err := newFreezer(dir, "", false, 0, 2049, tables)  // [bsc] putting 0 as initial offset
 	if err != nil {
 		t.Fatalf("can't reopen freezer after failed ModifyAncients: %v", err)
 	}
@@ -263,17 +263,17 @@ func TestFreezerReadonlyValidate(t *testing.T) {
 	defer os.RemoveAll(dir)
 	// Open non-readonly freezer and fill individual tables
 	// with different amount of data.
-	f, err := newFreezer(dir, "", false, 2049, tables)
+	f, err := newFreezer(dir, "", false, 0, 2049, tables) // [bsc] putting 0 as initial offset
 	if err != nil {
 		t.Fatal("can't open freezer", err)
 	}
 	var item = make([]byte, 1024)
-	aBatch := f.tables["a"].newBatch()
+	aBatch := f.tables["a"].newBatch(0) // [bsc] putting 0 as initial offset
 	require.NoError(t, aBatch.AppendRaw(0, item))
 	require.NoError(t, aBatch.AppendRaw(1, item))
 	require.NoError(t, aBatch.AppendRaw(2, item))
 	require.NoError(t, aBatch.commit())
-	bBatch := f.tables["b"].newBatch()
+	bBatch := f.tables["b"].newBatch(0) // [bsc] putting 0 as initial offset
 	require.NoError(t, bBatch.AppendRaw(0, item))
 	require.NoError(t, bBatch.commit())
 	if f.tables["a"].items != 3 {
@@ -286,7 +286,7 @@ func TestFreezerReadonlyValidate(t *testing.T) {
 
 	// Re-openening as readonly should fail when validating
 	// table lengths.
-	f, err = newFreezer(dir, "", true, 2049, tables)
+	f, err = newFreezer(dir, "", true, 0, 2049, tables) // [bsc] putting 0 as initial offset
 	if err == nil {
 		t.Fatal("readonly freezer should fail with differing table lengths")
 	}
@@ -301,7 +301,7 @@ func newFreezerForTesting(t *testing.T, tables map[string]bool) (*freezer, strin
 	}
 	// note: using low max table size here to ensure the tests actually
 	// switch between multiple files.
-	f, err := newFreezer(dir, "", false, 2049, tables)
+	f, err := newFreezer(dir, "", false, 0, 2049, tables) // [bsc] putting 0 as initial offset
 	if err != nil {
 		t.Fatal("can't open freezer", err)
 	}

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -72,6 +72,12 @@ var (
 	// fastTxLookupLimitKey tracks the transaction lookup limit during fast sync.
 	fastTxLookupLimitKey = []byte("FastTransactionLookupLimit")
 
+	// [bsc] offSet of new updated ancientDB.
+	offSetOfCurrentAncientFreezer = []byte("offSetOfCurrentAncientFreezer")
+
+	// [bsc] offSet of the ancientDB before updated version.
+	offSetOfLastAncientFreezer = []byte("offSetOfLastAncientFreezer")
+
 	// badBlockKey tracks the list of bad blocks seen by local
 	badBlockKey = []byte("InvalidBlock")
 

--- a/core/rawdb/table.go
+++ b/core/rawdb/table.go
@@ -95,6 +95,16 @@ func (t *table) ReadAncients(fn func(reader ethdb.AncientReader) error) (err err
 	return t.db.ReadAncients(fn)
 }
 
+// [bsc] ItemAmountInAncient returns the actual length of current ancientDB.
+func (t *table) ItemAmountInAncient() (uint64, error) {
+	return t.db.ItemAmountInAncient()
+}
+
+// [bsc] AncientOffSet returns the offset of current ancientDB.
+func (t *table) AncientOffSet() uint64 {
+	return t.db.AncientOffSet()
+}
+
 // TruncateHead is a noop passthrough that just forwards the request to the underlying
 // database.
 func (t *table) TruncateHead(items uint64) error {

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -28,14 +28,17 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
+	"github.com/prometheus/tsdb/fileutil"
 )
 
 const (
@@ -333,6 +336,215 @@ func (p *Pruner) Prune(root common.Hash) error {
 	}
 	log.Info("State bloom filter committed", "name", filterName)
 	return prune(p.snaptree, root, p.db, p.stateBloom, filterName, middleRoots, start)
+}
+// [bsc] pruner functions
+type BlockPruner struct {
+	oldAncientPath      string
+	newAncientPath      string
+	node                *node.Node
+	BlockAmountReserved uint64
+}
+
+func NewBlockPruner(n *node.Node, oldAncientPath, newAncientPath string, BlockAmountReserved uint64) *BlockPruner {
+	return &BlockPruner{
+		oldAncientPath:      oldAncientPath,
+		newAncientPath:      newAncientPath,
+		node:                n,
+		BlockAmountReserved: BlockAmountReserved,
+	}
+}
+
+func (p *BlockPruner) backupOldDb(name string, cache, handles int, namespace string, readonly, interrupt bool) error {
+	log.Info("backup", "oldAncientPath", p.oldAncientPath, "newAncientPath", p.newAncientPath)
+	// Open old db wrapper.
+	chainDb, err := p.node.OpenDatabaseWithFreezer(name, cache, handles, p.oldAncientPath, namespace, readonly, true, interrupt)
+	if err != nil {
+		log.Error("Failed to open ancient database", "err", err)
+		return err
+	}
+	defer chainDb.Close()
+	log.Info("chainDB opened successfully")
+
+	// Get the number of items in old ancient db.
+	itemsOfAncient, err := chainDb.ItemAmountInAncient()
+	log.Info("the number of items in ancientDB is ", "itemsOfAncient", itemsOfAncient)
+
+	// If we can't access the freezer or it's empty, abort.
+	if err != nil || itemsOfAncient == 0 {
+		log.Error("can't access the freezer or it's empty, abort")
+		return errors.New("can't access the freezer or it's empty, abort")
+	}
+
+	// If the items in freezer is less than the block amount that we want to reserve, it is not enough, should stop.
+	if itemsOfAncient < p.BlockAmountReserved {
+		log.Error("the number of old blocks is not enough to reserve,", "ancient items", itemsOfAncient, "the amount specified", p.BlockAmountReserved)
+		return errors.New("the number of old blocks is not enough to reserve")
+	}
+
+	var oldOffSet uint64
+	if interrupt {
+		// The interrupt scecario within this function is specific for old and new ancientDB exsisted concurrently,
+		// should use last version of offset for oldAncientDB, because current offset is
+		// actually of the new ancientDB_Backup, but what we want is the offset of ancientDB being backup.
+		oldOffSet = rawdb.ReadOffSetOfLastAncientFreezer(chainDb)
+	} else {
+		// Using current version of ancientDB for oldOffSet because the db for backup is current version.
+		oldOffSet = rawdb.ReadOffSetOfCurrentAncientFreezer(chainDb)
+	}
+	log.Info("the oldOffSet is ", "oldOffSet", oldOffSet)
+
+	// Get the start BlockNumber for pruning.
+	startBlockNumber := oldOffSet + itemsOfAncient - p.BlockAmountReserved
+	log.Info("new offset/new startBlockNumber is ", "new offset", startBlockNumber)
+
+	// Create new ancientdb backup and record the new and last version of offset in kvDB as well.
+	// For every round, newoffset actually equals to the startBlockNumber in ancient backup db.
+	frdbBack, err := rawdb.NewFreezerDb(chainDb, p.newAncientPath, namespace, readonly, startBlockNumber)
+	if err != nil {
+		log.Error("Failed to create ancient freezer backup", "err", err)
+		return err
+	}
+	defer frdbBack.Close()
+
+	offsetBatch := chainDb.NewBatch()
+	rawdb.WriteOffSetOfCurrentAncientFreezer(offsetBatch, startBlockNumber)
+	rawdb.WriteOffSetOfLastAncientFreezer(offsetBatch, oldOffSet)
+	if err := offsetBatch.Write(); err != nil {
+		log.Crit("Failed to write offset into disk", "err", err)
+	}
+
+	// It's guaranteed that the old/new offsets are updated as well as the new ancientDB are created if this flock exist.
+	lock, _, err := fileutil.Flock(filepath.Join(p.newAncientPath, "PRUNEFLOCKBACK"))
+	if err != nil {
+		log.Error("file lock error", "err", err)
+		return err
+	}
+
+	log.Info("prune info", "old offset", oldOffSet, "number of items in ancientDB", itemsOfAncient, "amount to reserve", p.BlockAmountReserved)
+	log.Info("new offset/new startBlockNumber recorded successfully ", "new offset", startBlockNumber)
+
+	start := time.Now()
+	// All ancient data after and including startBlockNumber should write into new ancientDB ancient_back.
+	for blockNumber := startBlockNumber; blockNumber < itemsOfAncient+oldOffSet; blockNumber++ {
+		blockHash := rawdb.ReadCanonicalHash(chainDb, blockNumber)
+		block := rawdb.ReadBlock(chainDb, blockHash, blockNumber)
+		receipts := rawdb.ReadRawReceipts(chainDb, blockHash, blockNumber)
+		borReceipts := []*types.Receipt{rawdb.ReadBorReceipt(chainDb, blockHash, blockNumber)}
+
+		// Calculate the total difficulty of the block
+		td := rawdb.ReadTd(chainDb, blockHash, blockNumber)
+		if td == nil {
+			return consensus.ErrUnknownAncestor
+		}
+		// Write into new ancient_back db.
+		if _, err := rawdb.WriteAncientBlocks(frdbBack, []*types.Block{block}, []types.Receipts{receipts}, []types.Receipts{borReceipts}, td); err != nil {
+			log.Error("failed to write new ancient", "err", err)
+			return err
+		}
+		// Print the log every 5s for better trace.
+		if common.PrettyDuration(time.Since(start)) > common.PrettyDuration(5*time.Second) {
+			log.Info("block backup process running successfully", "current blockNumber for backup", blockNumber)
+			start = time.Now()
+		}
+	}
+	lock.Release()
+	log.Info("block backup done", "current start blockNumber in ancientDB", startBlockNumber)
+	return nil
+}
+
+// BlockPruneBackup backup the ancient data for the old ancient db, i.e. the most recent 128 blocks in ancient db.
+func (p *BlockPruner) BlockPruneBackup(name string, cache, handles int, namespace string, readonly, interrupt bool) error {
+	start := time.Now()
+
+	if err := p.backupOldDb(name, cache, handles, namespace, readonly, interrupt); err != nil {
+		return err
+	}
+
+	log.Info("Block pruning backup successfully", "time duration since start is", common.PrettyDuration(time.Since(start)))
+	return nil
+}
+
+func (p *BlockPruner) RecoverInterruption(name string, cache, handles int, namespace string, readonly bool) error {
+	log.Info("RecoverInterruption for block prune")
+	newExist, err := CheckFileExist(p.newAncientPath)
+	if err != nil {
+		log.Error("newAncientDb path error")
+		return err
+	}
+
+	if newExist {
+		log.Info("New ancientDB_backup existed in interruption scenario")
+		flockOfAncientBack, err := CheckFileExist(filepath.Join(p.newAncientPath, "PRUNEFLOCKBACK"))
+		if err != nil {
+			log.Error("Failed to check flock of ancientDB_Back %v", err)
+			return err
+		}
+
+		// Indicating both old and new ancientDB existed concurrently.
+		// Delete directly for the new ancientdb to prune from start, e.g.: path ../chaindb/ancient_backup
+		if err := os.RemoveAll(p.newAncientPath); err != nil {
+			log.Error("Failed to remove old ancient directory %v", err)
+			return err
+		}
+		if flockOfAncientBack {
+			// Indicating the oldOffset/newOffset have already been updated.
+			if err := p.BlockPruneBackup(name, cache, handles, namespace, readonly, true); err != nil {
+				log.Error("Failed to prune")
+				return err
+			}
+		} else {
+			// Indicating the flock did not exist and the new offset did not be updated, so just handle this case as usual.
+			if err := p.BlockPruneBackup(name, cache, handles, namespace, readonly, false); err != nil {
+				log.Error("Failed to prune")
+				return err
+			}
+		}
+
+		if err := p.AncientDbReplacer(); err != nil {
+			log.Error("Failed to replace ancientDB")
+			return err
+		}
+	} else {
+		log.Info("New ancientDB_backup did not exist in interruption scenario")
+		// Indicating new ancientDB even did not be created, just prune starting at backup from startBlockNumber as usual,
+		// in this case, the new offset have not been written into kvDB.
+		if err := p.BlockPruneBackup(name, cache, handles, namespace, readonly, false); err != nil {
+			log.Error("Failed to prune")
+			return err
+		}
+		if err := p.AncientDbReplacer(); err != nil {
+			log.Error("Failed to replace ancientDB")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func CheckFileExist(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			// Indicating the file didn't exist.
+			return false, nil
+		}
+		return true, err
+	}
+	return true, nil
+}
+
+func (p *BlockPruner) AncientDbReplacer() error {
+	// Delete directly for the old ancientdb, e.g.: path ../chaindb/ancient
+	if err := os.RemoveAll(p.oldAncientPath); err != nil {
+		log.Error("Failed to remove old ancient directory %v", err)
+		return err
+	}
+
+	// Rename the new ancientdb path same to the old
+	if err := os.Rename(p.newAncientPath, p.oldAncientPath); err != nil {
+		log.Error("Failed to rename new ancient directory")
+		return err
+	}
+	return nil
 }
 
 // RecoverPruning will resume the pruning procedure during the system restart.

--- a/core/tests/blockchain_repair_test.go
+++ b/core/tests/blockchain_repair_test.go
@@ -1781,7 +1781,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -1884,7 +1884,7 @@ func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repair leads us
-	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}
@@ -1949,7 +1949,7 @@ func TestIssue23496(t *testing.T) {
 
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -2017,7 +2017,7 @@ func TestIssue23496(t *testing.T) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repair leads us
-	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err = rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/core/tests/blockchain_sethead_test.go
+++ b/core/tests/blockchain_sethead_test.go
@@ -1963,7 +1963,7 @@ func testSetHead(t *testing.T, tt *rewindTest, snapshots bool) {
 
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}

--- a/core/tests/blockchain_snapshot_test.go
+++ b/core/tests/blockchain_snapshot_test.go
@@ -68,7 +68,7 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*core.BlockChain, []*type
 	}
 	os.RemoveAll(datadir)
 
-	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false)
+	db, err := rawdb.NewLevelDBDatabaseWithFreezer(datadir, 0, 0, datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to create persistent database: %v", err)
 	}
@@ -273,7 +273,7 @@ func (snaptest *crashSnapshotTest) test(t *testing.T) {
 	db.Close()
 
 	// Start a new blockchain back up and see where the repair leads us
-	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false)
+	newdb, err := rawdb.NewLevelDBDatabaseWithFreezer(snaptest.datadir, 0, 0, snaptest.datadir, "", false, false, false)
 	if err != nil {
 		t.Fatalf("Failed to reopen persistent database: %v", err)
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -138,7 +138,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	ethashConfig.NotifyFull = config.Miner.NotifyFull
 
 	// Assemble the Ethereum object
-	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "eth/db/chaindata/", false)
+	// [bsc] adding disabledFreeze and isLastOffset param
+	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "eth/db/chaindata/", false, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -560,7 +560,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td, ttd *
 		} else {
 			d.ancientLimit = 0
 		}
-		frozen, _ := d.stateDB.Ancients() // Ignore the error here since light client can also hit here.
+		frozen, _ := d.stateDB.ItemAmountInAncient() // [bsc] Ignore the error here since light client can also hit here.
 
 		// If a part of blockchain data has already been written into active store,
 		// disable the ancient style insertion explicitly.

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -64,6 +64,7 @@ func newTester() *downloadTester {
 		panic(err)
 	}
 
+	// [bsc] adding disabledFreeze and isLastOffset param
 	db, err := rawdb.NewDatabaseWithFreezer(rawdb.NewMemoryDatabase(), freezer, "", false)
 	if err != nil {
 		panic(err)

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -72,6 +72,11 @@ func (eth *Ethereum) StateAtBlock(block *types.Block, reexec uint64, base *state
 		// The optional base statedb is given, mark the start point as parent block
 		statedb, database, report = base, base.Database(), false
 		current = eth.blockchain.GetBlock(block.ParentHash(), block.NumberU64()-1)
+		
+		// [bsc] returning error when no current found
+		if current == nil {
+			return nil, fmt.Errorf("missing parent block %v %d", block.ParentHash(), block.NumberU64()-1)
+		}
 	} else {
 		// Otherwise try to reexec blocks until we find a state or reach our limit
 		current = block

--- a/ethdb/database.go
+++ b/ethdb/database.go
@@ -93,6 +93,12 @@ type AncientReader interface {
 
 	// AncientSize returns the ancient size of the specified category.
 	AncientSize(kind string) (uint64, error)
+
+	// [bsc] ItemAmountInAncient returns the actual length of current ancientDB.
+	ItemAmountInAncient() (uint64, error)
+
+	// [bsc] AncientOffSet returns the offset of current ancientDB.
+	AncientOffSet() uint64
 }
 
 // AncientBatchReader is the interface for 'batched' or 'atomic' reading.

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -199,6 +199,12 @@ func Commands() map[string]MarkDownCommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		// [bsc] adding prune-block cli feature
+		"snapshot prune-block": func() (MarkDownCommand, error) {
+			return &PruneBlockCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 }
 

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -3,14 +3,23 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state/pruner"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/internal/cli/flagset"
 	"github.com/ethereum/go-ethereum/internal/cli/server"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/prometheus/tsdb/fileutil"
 
 	"github.com/mitchellh/cli"
 )
@@ -161,7 +170,8 @@ func (c *PruneStateCommand) Run(args []string) int {
 		return 1
 	}
 
-	chaindb, err := node.OpenDatabaseWithFreezer(chaindataPath, int(c.cache), dbHandles, c.datadirAncient, "", false)
+	// [bsc] adding disabledFreeze and isLastOffset param
+	chaindb, err := node.OpenDatabaseWithFreezer(chaindataPath, int(c.cache), dbHandles, c.datadirAncient, "", false, false, false)
 
 	if err != nil {
 		c.UI.Error(err.Error())
@@ -180,4 +190,355 @@ func (c *PruneStateCommand) Run(args []string) int {
 	}
 
 	return 0
+}
+// [bsc] prune block feature addition
+type PruneBlockCommand struct {
+	*Meta
+
+	datadirAncient       string
+	cache                int
+	blockAmountReserved  uint64
+	triesInMemory        int
+	checkSnapshotWithMPT bool
+}
+
+// MarkDown implements cli.MarkDown interface
+func (c *PruneBlockCommand) MarkDown() string {
+	items := []string{
+		"# Prune block",
+		"The ```bor snapshot prune-block``` command will prune ancient blockchain offline",
+		c.Flags().MarkDown(),
+	}
+
+	return strings.Join(items, "\n\n")
+}
+
+// Help implements the cli.Command interface
+func (c *PruneBlockCommand) Help() string {
+	return `Usage: bor snapshot prune-block <datadir>
+
+  This command will prune blockchain databases at the given datadir location` + c.Flags().Help()
+}
+
+// Synopsis implements the cli.Command interface
+func (c *PruneBlockCommand) Synopsis() string {
+	return "Prune ancient data"
+}
+
+// Flags: datadir, datadir.ancient, cache.trie.journal, bloomfilter.size
+func (c *PruneBlockCommand) Flags() *flagset.Flagset {
+	flags := c.NewFlagSet("prune-block")
+
+	flags.StringFlag(&flagset.StringFlag{
+		Name:    "datadir.ancient",
+		Value:   &c.datadirAncient,
+		Usage:   "Path of the ancient data directory to store information",
+		Default: "",
+	})
+
+	flags.IntFlag(&flagset.IntFlag{
+		Name:    "cache",
+		Usage:   "Megabytes of memory allocated to internal caching",
+		Value:   &c.cache,
+		Default: 1024,
+		Group:   "Cache",
+	})
+	flags.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "block-amount-reserved",
+		Usage:   "Sets the expected remained amount of blocks for offline block prune",
+		Value:   &c.blockAmountReserved,
+		Default: 1024,
+	})
+
+	flags.IntFlag(&flagset.IntFlag{
+		Name:    "cache.triesinmemory",
+		Usage:   "Number of block states (tries) to keep in memory (default = 128)",
+		Value:   &c.triesInMemory,
+		Default: 128,
+	})
+
+	flags.BoolFlag(&flagset.BoolFlag{
+		Name:  "check-snapshot-with-mpt",
+		Value: &c.checkSnapshotWithMPT,
+		Usage: "Path of the trie journal directory to store information",
+	})
+
+	return flags
+}
+
+// Run implements the cli.Command interface
+func (c *PruneBlockCommand) Run(args []string) int {
+	flags := c.Flags()
+
+	if err := flags.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	datadir := c.dataDir
+	if datadir == "" {
+		c.UI.Error("datadir is required")
+		return 1
+	}
+
+	// Create the node
+	node, err := node.New(&node.Config{
+		DataDir: datadir,
+	})
+
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	defer node.Close()
+
+	dbHandles, err := server.MakeDatabaseHandles()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	err = c.accessDb(node, dbHandles)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	err = c.pruneBlock(node, dbHandles)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+	return 0
+}
+
+func (c *PruneBlockCommand) accessDb(stack *node.Node, dbHandles int) error {
+	chaindb, err := stack.OpenDatabaseWithFreezer(chaindataPath, c.cache, dbHandles, c.datadirAncient, "", false, true, false)
+	if err != nil {
+		return fmt.Errorf("failed to accessdb %v", err)
+	}
+	defer chaindb.Close()
+
+	if !c.checkSnapshotWithMPT {
+		return nil
+	}
+	headBlock := rawdb.ReadHeadBlock(chaindb)
+	if headBlock == nil {
+		return errors.New("failed to load head block")
+	}
+	headHeader := headBlock.Header()
+	//Make sure the MPT and snapshot matches before pruning, otherwise the node can not start.
+	snaptree, err := snapshot.New(chaindb, trie.NewDatabase(chaindb), 256, headBlock.Root(), false, false, false)
+	if err != nil {
+		log.Error("snaptree error", "err", err)
+		return err // The relevant snapshot(s) might not exist
+	}
+
+	// Use the HEAD-(n-1) as the target root. The reason for picking it is:
+	// - in most of the normal cases, the related state is available
+	// - the probability of this layer being reorg is very low
+
+	// Retrieve all snapshot layers from the current HEAD.
+	// In theory there are n difflayers + 1 disk layer present,
+	// so n diff layers are expected to be returned.
+	layers := snaptree.Snapshots(headHeader.Root, c.triesInMemory, true)
+	if len(layers) != c.triesInMemory {
+		// Reject if the accumulated diff layers are less than n. It
+		// means in most of normal cases, there is no associated state
+		// with bottom-most diff layer.
+		log.Error("snapshot layers != TriesInMemory", "err", err)
+		return fmt.Errorf("snapshot not old enough yet: need %d more blocks", c.triesInMemory-len(layers))
+	}
+	// Use the bottom-most diff layer as the target
+	targetRoot := layers[len(layers)-1].Root()
+
+	// Ensure the root is really present. The weak assumption
+	// is the presence of root can indicate the presence of the
+	// entire trie.
+	if blob := rawdb.ReadTrieNode(chaindb, targetRoot); len(blob) == 0 {
+		// The special case is for clique based networks(rinkeby, goerli
+		// and some other private networks), it's possible that two
+		// consecutive blocks will have same root. In this case snapshot
+		// difflayer won't be created. So HEAD-(n-1) may not paired with
+		// head-(n-1) layer. Instead the paired layer is higher than the
+		// bottom-most diff layer. Try to find the bottom-most snapshot
+		// layer with state available.
+		//
+		// Note HEAD is ignored. Usually there is the associated
+		// state available, but we don't want to use the topmost state
+		// as the pruning target.
+		var found bool
+		for i := len(layers) - 2; i >= 1; i-- {
+			if blob := rawdb.ReadTrieNode(chaindb, layers[i].Root()); len(blob) != 0 {
+				targetRoot = layers[i].Root()
+				found = true
+				log.Info("Selecting middle-layer as the pruning target", "root", targetRoot, "depth", i)
+				break
+			}
+		}
+		if !found {
+			if blob := rawdb.ReadTrieNode(chaindb, snaptree.DiskRoot()); len(blob) != 0 {
+				targetRoot = snaptree.DiskRoot()
+				found = true
+				log.Info("Selecting disk-layer as the pruning target", "root", targetRoot)
+			}
+		}
+		if !found {
+			if len(layers) > 0 {
+				log.Error("no snapshot paired state")
+				return errors.New("no snapshot paired state")
+			}
+			return fmt.Errorf("associated state[%x] is not present", targetRoot)
+		}
+	} else {
+		if len(layers) > 0 {
+			log.Info("Selecting bottom-most difflayer as the pruning target", "root", targetRoot, "height", headHeader.Number.Uint64()-uint64(len(layers)-1))
+		} else {
+			log.Info("Selecting user-specified state as the pruning target", "root", targetRoot)
+		}
+	}
+
+	isDeleteActive := true
+	// [mys] additional active data pruning
+	if isDeleteActive {
+		// Wipe out older data from the active database
+		batchActive 			:= chaindb.NewBatch()
+		timePrune 				:= time.Now()
+		timeCompactIteration 	:= time.Now()
+		blockToKeep 			:= uint64(552120)
+		blockToDelete			:= uint64(10000)
+
+		var activeHashes []*rawdb.NumberHash
+		var activeNumber, itDeleteActive uint64
+
+		// headNumber := rawdb.ReadHeaderNumber(nfdb, hash)
+		log.Info("[ucc] got active data ----- ", "headBlock", headBlock.NumberU64())
+		headNumber := headBlock.NumberU64()
+
+		if headNumber < blockToKeep {
+			log.Info("[ucc] active data still less than magic number ---- ")
+		} else {
+			endBlockToDelete := headNumber - blockToKeep
+			log.Info("[ucc] active data preparing to delete --- ", "start", 1, "end", endBlockToDelete)
+
+			for itDeleteActive = uint64(0); itDeleteActive < endBlockToDelete; itDeleteActive += blockToDelete {
+				timeCompactIteration = time.Now()
+
+				batchActive = chaindb.NewBatch()
+
+				deleteStart := itDeleteActive
+				// keep block 0 genesis, start from block 1 instead
+				if deleteStart == 0 {
+					deleteStart += 1
+				}
+
+				deleteEnd := itDeleteActive + blockToDelete
+				if deleteEnd > endBlockToDelete {
+					deleteEnd = endBlockToDelete
+				}
+
+				activeHashes = rawdb.ReadAllHashesInRange(chaindb, deleteStart, deleteEnd)
+
+				for _, hashes := range activeHashes {
+					rawdb.DeleteBlock(batchActive, hashes.Hash, activeNumber)
+				}
+			
+				if err := batchActive.Write(); err != nil {
+					log.Crit("[ucc] active data delete failed ---- ", "err", err)
+				}
+
+				log.Info("[ucc] active data delete staging --- ", "start", deleteStart, "end", deleteEnd, "elapsed", common.PrettyDuration(time.Since(timeCompactIteration)))
+					
+				batchActive.Reset()
+			}
+
+			log.Info("[ucc] active data delete completed --- ", "elapsed", common.PrettyDuration(time.Since(timePrune)))
+
+				
+			// --- compaction
+			cstart := time.Now()
+			for bCompact := 0x00; bCompact <= 0xf0; bCompact += 0x10 {
+				var (
+					startCompact = []byte{byte(bCompact)}
+					endCompact   = []byte{byte(bCompact + 0x10)}
+				)
+				if bCompact == 0xf0 {
+					endCompact = nil
+				}
+				log.Info("[ucc] Compacting database ---- ", "bCompact", bCompact, "range", fmt.Sprintf("%#x-%#x", startCompact, endCompact), "elapsed", common.PrettyDuration(time.Since(cstart)))
+				if err := chaindb.Compact(startCompact, endCompact); err != nil {
+					log.Error("[ucc] Database compaction failed ---- ", "error", err)
+				}
+			}
+			log.Info("[ucc] Database compaction finished ---- ", "elapsed", common.PrettyDuration(time.Since(cstart)))
+
+			log.Info("[ucc] State pruning successful ---- ", "elapsed", common.PrettyDuration(time.Since(timePrune)))
+			// --- end compaction
+		}
+	}
+	// --
+	return nil
+}
+
+func (c *PruneBlockCommand) pruneBlock(stack *node.Node, fdHandles int) error {
+	name := "chaindata"
+
+	oldAncientPath := c.datadirAncient
+	switch {
+	case oldAncientPath == "":
+		oldAncientPath = filepath.Join(stack.ResolvePath(name), "ancient")
+	case !filepath.IsAbs(oldAncientPath):
+		oldAncientPath = stack.ResolvePath(oldAncientPath)
+	}
+
+	path, _ := filepath.Split(oldAncientPath)
+	if path == "" {
+		return errors.New("prune failed, did not specify the AncientPath")
+	}
+	newAncientPath := filepath.Join(path, "ancient_back")
+
+	blockpruner := pruner.NewBlockPruner(stack, oldAncientPath, newAncientPath, c.blockAmountReserved)
+
+	lock, exist, err := fileutil.Flock(filepath.Join(oldAncientPath, "PRUNEFLOCK"))
+	if err != nil {
+		log.Error("file lock error", "err", err)
+		return err
+	}
+	if exist {
+		defer lock.Release()
+		log.Info("file lock existed, waiting for prune recovery and continue", "err", err)
+		if err := blockpruner.RecoverInterruption("chaindata", c.cache, fdHandles, "", false); err != nil {
+			log.Error("Pruning failed", "err", err)
+			return err
+		}
+		log.Info("Block prune successfully")
+		return nil
+	}
+
+	if _, err := os.Stat(newAncientPath); err == nil {
+		// No file lock found for old ancientDB but new ancientDB exsisted, indicating the geth was interrupted
+		// after old ancientDB removal, this happened after backup successfully, so just rename the new ancientDB
+		if err := blockpruner.AncientDbReplacer(); err != nil {
+			log.Error("Failed to rename new ancient directory")
+			return err
+		}
+		log.Info("Block prune successfully")
+		return nil
+	}
+	if err := blockpruner.BlockPruneBackup(name, c.cache, fdHandles, "", false, false); err != nil {
+		log.Error("Failed to backup block", "err", err)
+		return err
+	}
+
+	log.Info("Block backup successfully")
+
+	// After backup successfully, rename the new ancientdb name to the original one, and delete the old ancientdb
+	if err := blockpruner.AncientDbReplacer(); err != nil {
+		return err
+	}
+
+	lock.Release()
+	log.Info("Block prune successfully")
+
+	return nil
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -636,6 +636,10 @@ func (s *PublicBlockChainAPI) GetTransactionReceiptsByBlock(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	// [bsc] error handler when no receipt found
+	if receipts == nil {
+		return nil, fmt.Errorf("block %d receipts not found", block.NumberU64())
+	}
 
 	txs := block.Transactions()
 

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -192,15 +192,6 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
-		new web3._extend.Method({
-			name: 'getMaxPeers',
-			call: 'admin_getMaxPeers'
-		}),
-		new web3._extend.Method({
-			name: 'setMaxPeers',
-			call: 'admin_setMaxPeers',
-			params: 1
-		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/node/api.go
+++ b/node/api.go
@@ -61,30 +61,6 @@ type privateAdminAPI struct {
 	node *Node // Node interfaced by this API
 }
 
-// This function sets the param maxPeers for the node. If there are excess peers attached to the node, it will remove the difference.
-func (api *privateAdminAPI) SetMaxPeers(maxPeers int) (bool, error) {
-	// Make sure the server is running, fail otherwise
-	server := api.node.Server()
-	if server == nil {
-		return false, ErrNodeStopped
-	}
-
-	server.SetMaxPeers(maxPeers)
-
-	return true, nil
-}
-
-// This function gets the maxPeers param for the node.
-func (api *privateAdminAPI) GetMaxPeers() (int, error) {
-	// Make sure the server is running, fail otherwise
-	server := api.node.Server()
-	if server == nil {
-		return 0, ErrNodeStopped
-	}
-
-	return server.MaxPeers, nil
-}
-
 // AddPeer requests connecting to a remote node, and also maintaining the new
 // connection at all times, even reconnecting if it is lost.
 func (api *privateAdminAPI) AddPeer(url string) (bool, error) {

--- a/node/node.go
+++ b/node/node.go
@@ -719,7 +719,8 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 // also attaching a chain freezer to it that moves ancient chain data from the
 // database to immutable append-only files. If the node is an ephemeral one, a
 // memory database is returned.
-func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly bool) (ethdb.Database, error) {
+// [bsc] adding disabledFreeze and isLastOffset param
+func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer, namespace string, readonly, disableFreeze, isLastOffset bool) (ethdb.Database, error) {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 	if n.state == closedState {
@@ -738,7 +739,8 @@ func (n *Node) OpenDatabaseWithFreezer(name string, cache, handles int, freezer,
 		case !filepath.IsAbs(freezer):
 			freezer = n.ResolvePath(freezer)
 		}
-		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly)
+		// [bsc] sending disabledFreeze and isLastOffset param
+		db, err = rawdb.NewLevelDBDatabaseWithFreezer(root, cache, handles, freezer, namespace, readonly, disableFreeze, isLastOffset)
 	}
 
 	if err == nil {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -307,35 +307,6 @@ func (srv *Server) Peers() []*Peer {
 	return ps
 }
 
-// This function retrieves the peers that are not trusted-peers
-func (srv *Server) getNonTrustedPeers() []*Peer {
-	allPeers := srv.Peers()
-
-	nontrustedPeers := []*Peer{}
-
-	for _, peer := range allPeers {
-		if !peer.Info().Network.Trusted {
-			nontrustedPeers = append(nontrustedPeers, peer)
-		}
-	}
-
-	return nontrustedPeers
-}
-
-// SetMaxPeers sets the maximum number of peers that can be connected
-func (srv *Server) SetMaxPeers(maxPeers int) {
-	currentPeers := srv.getNonTrustedPeers()
-	if len(currentPeers) > maxPeers {
-		peersToDrop := currentPeers[maxPeers:]
-		for _, peer := range peersToDrop {
-			log.Warn("CurrentPeers more than MaxPeers", "removing", peer.ID())
-			srv.RemovePeer(peer.Node())
-		}
-	}
-
-	srv.MaxPeers = maxPeers
-}
-
 // PeerCount returns the number of connected peers.
 func (srv *Server) PeerCount() int {
 	var count int
@@ -397,8 +368,6 @@ func (srv *Server) RemoveTrustedPeer(node *enode.Node) {
 	case srv.removetrusted <- node:
 	case <-srv.quit:
 	}
-	// Disconnect the peer if maxPeers is breached.
-	srv.SetMaxPeers(srv.MaxPeers)
 }
 
 // SubscribeEvents subscribes the given channel to peer events

--- a/params/network_params.go
+++ b/params/network_params.go
@@ -57,7 +57,9 @@ const (
 	// considered immutable (i.e. soft finality). It is used by the downloader as a
 	// hard limit against deep ancestors, by the blockchain against deep reorgs, by
 	// the freezer as the cutoff threshold and by clique as the snapshot trust limit.
-	FullImmutabilityThreshold = 90000
+	// FullImmutabilityThreshold = 90000
+	// [mys] reducing imutable block amount which can save more resource to avoid db corrupt
+	FullImmutabilityThreshold = 9
 
 	// LightImmutabilityThreshold is the number of blocks after which a header chain
 	// segment is considered immutable for light client(i.e. soft finality). It is used by


### PR DESCRIPTION
# Changes

- [x] Additional code changes for ancient pruning taken from BSC ([master commit](https://github.com/bnb-chain/bsc/commit/6587671e748805a438c4c617e766ce168a38e5e6))
- [x] Implementing logic for active data real time pruning, which will discard older data
- [x] Implementing ancient data history dropping
- [x] Disabling ancient data db write
