### PR TITLE
Restoring db inspect and db command CLI

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -376,7 +376,8 @@ func inspect(ctx *cli.Context) error {
 	db := utils.MakeChainDatabase(ctx, stack, true, false)
 	defer db.Close()
 
-	return rawdb.InspectDatabase(db, prefix, start)
+	// [mys] inspect & do not show unaccounted error for pruned data
+	return rawdb.InspectDatabase(db, prefix, start, true)
 }
 
 func showLeveldbStats(db ethdb.Stater) {

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -375,7 +375,7 @@ func (s *stat) Count() string {
 
 // InspectDatabase traverses the entire database and checks the size
 // of all different categories of data.
-func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
+func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte, showUnaccountedError bool) error {
 	it := db.NewIterator(keyPrefix, keyStart)
 	defer it.Release()
 
@@ -540,7 +540,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	table.AppendBulk(stats)
 	table.Render()
 
-	if unaccounted.size > 0 {
+	// [mys] only show unaccounted error when needed
+	if showUnaccountedError && unaccounted.size > 0 {
 		log.Error("Database contains unaccounted data", "size", unaccounted.size, "count", unaccounted.count)
 	}
 

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -205,6 +205,18 @@ func Commands() map[string]MarkDownCommandFactory {
 				Meta: meta,
 			}, nil
 		},
+
+		// [mys] adding db cli
+		"db inspect": func() (MarkDownCommand, error) {
+			return &DBInspectCommand{
+				Meta: meta,
+			}, nil
+		},
+		"db compact": func() (MarkDownCommand, error) {
+			return &DBCompactCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 }
 

--- a/internal/cli/db_compact.go
+++ b/internal/cli/db_compact.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/internal/cli/flagset"
+	"github.com/ethereum/go-ethereum/internal/cli/server"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+// DBCompactCommand is for compacting database storage
+type DBCompactCommand struct {
+	*Meta
+
+	datadir 	string
+	cache 		uint64
+}
+
+// MarkDown implements cli.MarkDown interface
+func (c *DBCompactCommand) MarkDown() string {
+	items := []string{
+		"# db",
+		"The ```bor db compact``` command will compact database size",
+		c.Flags().MarkDown(),
+	}
+
+	return strings.Join(items, "\n\n")
+}
+
+// Help implements the cli.Command interface
+func (c *DBCompactCommand) Help() string {
+	return `Usage: bor db compact <datadir> <cache>
+
+  This command compacting the entire database size within given datadir, with optional cache (default 1024 -MB-)`
+}
+
+// Synopsis implements the cli.Command interface
+func (c *DBCompactCommand) Synopsis() string {
+	return "Compacting storage size of databases"
+}
+
+func (c *DBCompactCommand) Flags() *flagset.Flagset {
+	flags := c.NewFlagSet("dbcompact")
+
+	flags.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "cache",
+		Usage:   "Megabytes of memory allocated to internal caching",
+		Value:   &c.cache,
+		Default: 1024.0,
+		Group:   "Cache",
+	})
+
+	return flags
+}
+
+func (c *DBCompactCommand) Run(args []string) int {
+	flags := c.Flags()
+
+	// parse datadir
+	if err := flags.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	datadir := c.dataDir
+	if datadir == "" {
+		c.UI.Error("--datadir is required")
+		return 1
+	}
+
+	// Create the node
+	node, err := node.New(&node.Config{
+		DataDir: datadir,
+	})
+
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	dbHandles, err := server.MakeDatabaseHandles()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	log.Info("Opening database")
+	chaindb, err := node.OpenDatabase(chaindataPath, int(c.cache), dbHandles, "", false)
+
+	if err != nil {
+		log.Info("err --- ", "err", err)
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	log.Info("Stats before compaction")
+	showLeveldbStats(chaindb)
+	
+	log.Info("Triggering compaction")
+	if err := chaindb.Compact(nil, nil); err != nil {
+		log.Info("Compact err", "error", err)
+		return 1
+	}
+	log.Info("Stats after compaction")
+	showLeveldbStats(chaindb)
+	
+	return 0
+}
+
+func showLeveldbStats(db ethdb.Stater) {
+	if stats, err := db.Stat("leveldb.stats"); err != nil {
+		log.Warn("Failed to read database stats", "error", err)
+	} else {
+		fmt.Println(stats)
+	}
+	if ioStats, err := db.Stat("leveldb.iostats"); err != nil {
+		log.Warn("Failed to read database iostats", "error", err)
+	} else {
+		fmt.Println(ioStats)
+	}
+}

--- a/internal/cli/db_inspect.go
+++ b/internal/cli/db_inspect.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/internal/cli/flagset"
+	"github.com/ethereum/go-ethereum/internal/cli/server"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+)
+
+// DBInspectCommand is for inspecting database storage
+type DBInspectCommand struct {
+	*Meta
+
+	datadir 	string
+	cache 		uint64
+}
+
+// MarkDown implements cli.MarkDown interface
+func (c *DBInspectCommand) MarkDown() string {
+	items := []string{
+		"# db",
+		"The ```bor db inspect``` command will inspect the storage size for each type of data in the database",
+		c.Flags().MarkDown(),
+	}
+
+	return strings.Join(items, "\n\n")
+}
+
+// Help implements the cli.Command interface
+func (c *DBInspectCommand) Help() string {
+	return `Usage: bor db inspect <datadir> <cache>
+
+  This command iterates the entire database within given datadir, with optional cache (default 1024 -MB-)`
+}
+
+// Synopsis implements the cli.Command interface
+func (c *DBInspectCommand) Synopsis() string {
+	return "Inspect storage size of databases"
+}
+
+func (c *DBInspectCommand) Flags() *flagset.Flagset {
+	flags := c.NewFlagSet("dbinspect")
+
+	flags.Uint64Flag(&flagset.Uint64Flag{
+		Name:    "cache",
+		Usage:   "Megabytes of memory allocated to internal caching",
+		Value:   &c.cache,
+		Default: 1024.0,
+		Group:   "Cache",
+	})
+
+	return flags
+}
+
+func (c *DBInspectCommand) Run(args []string) int {
+	var (
+		prefix []byte
+		start  []byte
+	)
+
+	flags := c.Flags()
+
+	// parse datadir
+	if err := flags.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	datadir := c.dataDir
+	if datadir == "" {
+		c.UI.Error("datadir is required")
+		return 1
+	}
+
+	// Create the node
+	node, err := node.New(&node.Config{
+		DataDir: datadir,
+	})
+
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	dbHandles, err := server.MakeDatabaseHandles()
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	chaindb, err := node.OpenDatabase(chaindataPath, int(c.cache), dbHandles, "", true)
+
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	rawdb.InspectDatabase(chaindb, prefix, start, false)
+	return 0
+}


### PR DESCRIPTION
# Description

This PR is to restore some removed cli commands

|  Command |  Details |
|------|---------|
|  `bor db inspect`  |   Inspecting database structure |
|   `bor db compact `  |  Compacting database size  |


Both parameters require : 
- --datadir parameter ( absolute path whch points to the data folder )
- --cache parameter ( default 1024 )
